### PR TITLE
Remove `mobileanalytics` due to invalid key error

### DIFF
--- a/bin/pulumilocal
+++ b/bin/pulumilocal
@@ -239,7 +239,6 @@ SERVICES = [
     'migrationhub',
     'migrationhubconfig',
     'mobile',
-    'mobileanalytics',
     'mq',
     'mturk',
     'mwaa',


### PR DESCRIPTION
Hi,

Referencing #5 this PR removes the now defunct `mobileanalytics` endpoint.

Related to https://github.com/localstack/docs/pull/319 

Hopefully this is enough to release a new version on PyPi.


Thanks!