### PR TITLE
fix(config): replace s3ForcePathStyle with s3UsePathStyle

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ You can configure the following environment variables:
 
 ## Change Log
 
+* v0.6: Replace deprecated `s3ForcePathStyle` with `s3UsePathStyle` in default config
 * v0.5: Remove deprecated `mobileanalytics` service config to fix invalid key error
 * v0.4: Point pulumilocal.bat to the correct script
 * v0.3: Add apigatewayv2 service endpoint

--- a/bin/pulumilocal
+++ b/bin/pulumilocal
@@ -31,7 +31,7 @@ DEFAULT_CONFIG = {
         'aws:secretKey': 'test',
         'aws:endpoints': [],
         'aws:region': 'us-east-1',
-        'aws:s3UsePathStyle': 'true'
+        'aws:s3UsePathStyle': 'true',
         'aws:skipCredentialsValidation': 'true',
         'aws:skipRequestingAccountId': 'true',
     }

--- a/bin/pulumilocal
+++ b/bin/pulumilocal
@@ -31,7 +31,7 @@ DEFAULT_CONFIG = {
         'aws:secretKey': 'test',
         'aws:endpoints': [],
         'aws:region': 'us-east-1',
-        'aws:s3ForcePathStyle': 'true',
+        'aws:s3UsePathStyle': 'true'
         'aws:skipCredentialsValidation': 'true',
         'aws:skipRequestingAccountId': 'true',
     }

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ if __name__ == '__main__':
 
     setup(
         name='pulumi-local',
-        version='0.5',
+        version='0.6',
         description='Thin wrapper script to use Pulumi with LocalStack',
         author='LocalStack Team',
         author_email='info@localstack.cloud',


### PR DESCRIPTION
s3ForcePathStyle is deprecated and causes a warning "provider config warning: Use s3_use_path_style instead.". This fix replaces s3ForcePathStyle with s3UsePathStyle make that warning go away.

Fixes localstack/pulumi-local#10