### PR TITLE
Updated to work with --cwd flag and other changes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,6 @@
 __pycache__/
 
 .idea
+
+Pulumi.*
+myproj

--- a/README.md
+++ b/README.md
@@ -3,6 +3,11 @@
 This package provides the `pulumilocal` command, which is a thin wrapper around the `pulumi`
 command line interface to use [`Pulumi`](https://github.com/pulumi/pulumi) with [LocalStack](https://github.com/localstack/localstack).
 
+## Version Notices
+### v1.0
+1. Removed PULUMI_STACK_NAME and no longer default to a Pulumi Stack name of `localstack`. The `pulumi` cmd and env determines the Stack name.
+
+
 ## Installation
 
 You can install the `pulumilocal` command via `pip`:
@@ -21,25 +26,23 @@ The `pulumilocal` command has the same usage as the `pulumi` command. For detail
 please refer to the man pages of `pulumi -h`.
 
 For example:
-### Create a new Pulumi Project
+### Create a new Pulumi Project with Stack name lsdev
 ```shell
-export PULUMI_STACK_NAME=lsdev
+mkdir myproj
 export PULUMI_CONFIG_PASSPHRASE=lsdevtest
-export PULUMI_BACKEND_URL=file://~/local-pulumi-state
-mkdir ~/local-pulumi-state
-mkdir mylsapp
-cd mylsapp
-pulumilocal new typescript -y -s $PULUMI_STACK_NAME
+export PULUMI_BACKEND_URL=file://`pwd`/myproj
+pulumilocal new typescript -y -s lsdev --cwd myproj
 ```
 
-### Select the lsdev Pulumi Stack (it's already selected if doing all of this in order)
+### Select and Create the lsdev Pulumi Stack
+This is unnecessary if you just did the `new typescript` command above as it will already be selected.
 ```shell
-pulumilocal stack select lsdev
+pulumilocal stack select -c lsdev --cwd myproj
 ```
 
 ### Deploy the stack to LocalStack
 ```shell
-pulumilocal up
+pulumilocal up --cwd myproj
 ```
 
 ## How it works
@@ -53,20 +56,10 @@ You can configure the following environment variables:
 * `LOCALSTACK_HOSTNAME`: Target host to use for connecting to LocalStack (default: `localhost`)
 * `EDGE_PORT`: Target port to use for connecting to LocalStack (default: `4566`)
 * `PULUMI_CMD`: Name of the executable Pulumi command on the system PATH (default: `pulumi`)
-* `PULUMI_STACK_NAME`: Name of the Pulumi stack used to configure local endpoints (default: `localstack`)
 
 ## Deploying to AWS
 Use your preferred Pulumi backend. https://www.pulumi.com/docs/concepts/state/#deciding-on-a-state-backend
 Change the `pulumilocal` command in the instructions above to `pulumi`.
-
-## Change Log
-
-* v0.6: Replace deprecated `s3ForcePathStyle` with `s3UsePathStyle` in default config
-* v0.5: Remove deprecated `mobileanalytics` service config to fix invalid key error
-* v0.4: Point pulumilocal.bat to the correct script
-* v0.3: Add apigatewayv2 service endpoint
-* v0.2: Add init command and add aws:region key by default
-* v0.1: Initial release
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -5,7 +5,8 @@ command line interface to use [`Pulumi`](https://github.com/pulumi/pulumi) with 
 
 ## Version Notices
 ### v1.0
-1. Removed PULUMI_STACK_NAME and no longer default to a Pulumi Stack name of `localstack`. The `pulumi` cmd and env determines the Stack name.
+1. Removed PULUMI_STACK_NAME environment variable.
+2. No longer default to a Pulumi Stack name of `localstack`. The `pulumi` cmd and env determines the Stack name.
 
 
 ## Installation
@@ -47,7 +48,9 @@ pulumilocal up --cwd myproj
 
 ## How it works
 
-When running a deployment command like `pulumilocal up`, the wrapper script creates a `Pulumi.localstack.yaml` config file with local endpoint definitions, and then deploys a Pulumi stack called `localstack` to your LocalStack instance on `localhost`.
+When running any pulumi deployment command like `pulumilocal ["up", "destroy", "preview", "cancel"]`,
+the wrapper script runs the `pulumi config` command to augment the pulumi config with LocalStack AWS configuration,
+and then runs the original pulumi command. 
 
 ## Configurations
 

--- a/bin/pulumilocal
+++ b/bin/pulumilocal
@@ -10,7 +10,8 @@ Options:
 
 import os
 import sys
-import yaml
+import argparse
+import subprocess
 
 # for local testing
 PARENT_FOLDER = os.path.realpath(os.path.join(os.path.dirname(__file__), '..'))
@@ -20,22 +21,13 @@ if os.path.isdir(os.path.join(PARENT_FOLDER, '.venv')):
 # define global constants
 TRUE_STRINGS = ['1', 'true', 'True']
 PULUMI_CMD = os.environ.get('PULUMI_CMD') or 'pulumi'
-PULUMI_STACK_NAME = os.environ.get('PULUMI_STACK_NAME') or 'localstack'
 LOCALSTACK_HOSTNAME = os.environ.get('LOCALSTACK_HOSTNAME') or 'localhost'
 EDGE_PORT = int(os.environ.get('EDGE_PORT') or '4566')
 USE_SSL = os.environ.get('USE_SSL') in TRUE_STRINGS
 
-DEFAULT_CONFIG = {
-    'config': {
-        'aws:accessKey': 'test',
-        'aws:secretKey': 'test',
-        'aws:endpoints': [],
-        'aws:region': 'us-east-1',
-        'aws:s3UsePathStyle': 'true',
-        'aws:skipCredentialsValidation': 'true',
-        'aws:skipRequestingAccountId': 'true',
-    }
-}
+# Do not allow PULUMI_CMD env var to be set to pulumilocal as this causes an error
+if PULUMI_CMD == "pulumilocal":
+    PULUMI_CMD = "pulumi"
 
 # Unfortunately, we need to hardcode the service names here, as importing from
 # localstack-client doesn't work (some keys differ / are unavailable in Pulumi)
@@ -349,44 +341,62 @@ def get_service_endpoint():
     return endpoint
 
 
-def prepare_config_file():
-    file_name = 'Pulumi.%s.yaml' % PULUMI_STACK_NAME
-    if os.path.exists(file_name):
-        return file_name
-
-    # construct endpoints config
-    endpoint = get_service_endpoint()
-    endpoints = DEFAULT_CONFIG['config']['aws:endpoints']
-    if not endpoints:
-        entry = {service: endpoint for service in SERVICES}
-        endpoints.append(entry)
-
-    # write local config file
-    with open(file_name, 'w') as fp:
-        fp.write(yaml.dump(DEFAULT_CONFIG))
-    return file_name
-
-
-def prepare_cmd_args():
-    """
-    Constructs command line arguments for running the "pulumi" CLI
-    """
-    cmd_args = list(sys.argv)
-    if 'up' in cmd_args and '-s' not in cmd_args:
-        cmd_args += ['-s', PULUMI_STACK_NAME]
-    return cmd_args
+def set_localstack_pulumi_config(args: argparse.Namespace):
+    # LocalStack Endpoint
+    service_url = get_service_endpoint()
+    # Create argument list to pulumi config set-all
+    config_args = list()
+    config_args.append(PULUMI_CMD)
+    config_args.append("config")
+    if args.stack is not None:
+        config_args.append("--stack")
+        config_args.append(args.stack)
+    if args.cwd is not None:
+        config_args.append("--cwd")
+        config_args.append(args.cwd)
+    config_args.append("set-all")
+    config_args.append("--plaintext")
+    config_args.append("aws:region=us-east-1")
+    config_args.append("--plaintext")
+    config_args.append("aws:accessKey=test")
+    config_args.append("--plaintext")
+    config_args.append("aws:secretKey=test")
+    config_args.append("--plaintext")
+    config_args.append("aws:s3UsePathStyle=true")
+    config_args.append("--plaintext")
+    config_args.append("aws:skipCredentialsValidation=true")
+    config_args.append("--plaintext")
+    config_args.append("aws:skipRequestingAccountId=true")
+    for idx, service in enumerate(SERVICES):
+        config_args.append("--path")
+        config_args.append("--plaintext")
+        config_args.append(f"aws:endpoints[{idx}].{service}={service_url}")
+    # print(f"executing: {PULUMI_CMD} {config_args}")
+    process = subprocess.Popen(executable=PULUMI_CMD, args=config_args, env=os.environ, stdout=subprocess.PIPE)
+    process.wait()
+    # print(f"process.returncode: {process.returncode}")
 
 
 def main():
-    prepare_config_file()
+    # Parse arguments from call to pulumi CLI that set the stack name and directory
+    parser = argparse.ArgumentParser(add_help=False)
+    parser.add_argument("command", help="pulumi primary command",
+                        type=str)
+    parser.add_argument("-s", "--stack", help="pulumi stack name",
+                        required=False,
+                        type=str)
+    parser.add_argument("-C", "--cwd", help="run in this directory",
+                        required=False,
+                        type=str)
+    args, extra = parser.parse_known_args()
+    print(f"command {args.command}")
 
-    if sys.argv[1] == 'init':
-        # TODO: proper CLI using click/argparse
-        cmd_args = [sys.argv[0], 'stack', 'init', PULUMI_STACK_NAME]
-    else:
-        cmd_args = prepare_cmd_args()
-
-    return os.execvp(PULUMI_CMD, cmd_args)
+    # If this is a pulumi deployment command, update the stack with LocalStack AWS config
+    if args.command in ["up", "destroy", "preview", "cancel"]:
+        print("Updating this Stack with LocalStack config")
+        set_localstack_pulumi_config(args)
+    # Run the original command
+    return os.execvp(PULUMI_CMD, sys.argv)
 
 
 if __name__ == '__main__':

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ if __name__ == '__main__':
 
     setup(
         name='pulumi-local',
-        version='0.6',
+        version='1.0',
         description='Thin wrapper script to use Pulumi with LocalStack',
         author='LocalStack Team',
         author_email='info@localstack.cloud',
@@ -15,12 +15,9 @@ if __name__ == '__main__':
         scripts=['bin/pulumilocal', 'bin/pulumilocal.bat'],
         package_data={},
         data_files={},
-        install_requires=['pyyaml'],
+        install_requires=[],
         license="Apache License 2.0",
         classifiers=[
-            "Programming Language :: Python :: 2",
-            "Programming Language :: Python :: 2.6",
-            "Programming Language :: Python :: 2.7",
             "Programming Language :: Python :: 3",
             "Programming Language :: Python :: 3.3",
             "Programming Language :: Python :: 3.6",


### PR DESCRIPTION
    Updated to use pulumi config to set the LocalStack AWS config
    Removed dependency on pyyaml
    Removed Python2 classifiers from setup.py
    Added argparse processing to handle args to set stack name and target directory
    This is more resilient as it uses the pulumi CLI to augment the config. So config format could change and this would still work.

Tested locally with simple project and more complex one.