### PR TITLE
Added README to long description and update twine publish

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ endif
 VENV_RUN = . $(VENV_ACTIVATE)
 $(VENV_ACTIVATE):
 	test -d $(VENV_DIR) || $(VENV_BIN) $(VENV_DIR)
-	$(VENV_RUN); $(PIP_CMD) install --upgrade pip setuptools twine
+	$(VENV_RUN); $(PIP_CMD) install --upgrade pip setuptools wheel twine
 	$(VENV_RUN); $(PIP_CMD) install $(PIP_OPTS) -r $(VENV_REQS_FILE)
 	touch $(VENV_ACTIVATE)
 

--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@ Change the `pulumilocal` command in the instructions above to `pulumi`.
 
 ## Change Log
 
+* v1.1: Added README to long description and update twine publish.
 * v1.0: Using `pulumi config set-all` to set all the AWS provider configurating instead of modifying
   the Stack file directly. Removed defaulting the stack name to `localstack`. Added argparse. 
   Removed pyyaml dependency. Removed python2 package classifiers. 

--- a/setup.py
+++ b/setup.py
@@ -1,13 +1,19 @@
 #!/usr/bin/env python
 
 from setuptools import setup
+# read the contents of your README file
+from pathlib import Path
+this_directory = Path(__file__).parent
+long_description = (this_directory / "README.md").read_text()
 
 if __name__ == '__main__':
 
     setup(
         name='pulumi-local',
-        version='1.0',
+        version='1.1',
         description='Thin wrapper script to use Pulumi with LocalStack',
+        long_description=long_description,
+        long_description_content_type='text/markdown',
         author='LocalStack Team',
         author_email='info@localstack.cloud',
         url='https://github.com/localstack/pulumi-local',


### PR DESCRIPTION
README now part of pypi long description.
<img width="1318" alt="Screenshot 2023-08-17 at 11 40 19 AM" src="https://github.com/localstack/pulumi-local/assets/850718/8aa023e6-b9e4-4ecd-b972-06692598e8ee">
