### PR TITLE
Config merge

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -26,10 +26,10 @@ jobs:
 
     - name: Install Pulumi CLI
       uses: pulumi/setup-pulumi@v2
-    - name: Set up Python 3.11
+    - name: Set up Python 3.12
       uses: actions/setup-python@v2
       with:
-        python-version: '3.11'
+        python-version: '3.12'
 
     - name: Install dependencies
       run: make install

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,6 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       AWS_DEFAULT_REGION: us-east-1
+      PYTHONUNBUFFERED: 1
 
     steps:
     - name: Check out code

--- a/Makefile
+++ b/Makefile
@@ -35,5 +35,7 @@ test: venv       	## Run unit/integration tests
 
 clean:             	## Clean up
 	rm -rf $(VENV_DIR)
+	rm -rf dist
+	rm -rf *.egg-info
 
 .PHONY: clean publish install usage lint test venv

--- a/README.md
+++ b/README.md
@@ -64,6 +64,13 @@ You can configure the following environment variables:
 * `LOCALSTACK_HOSTNAME`: __(Deprecated)__ Target host to use for connecting to LocalStack (default: `localhost`)
 * `EDGE_PORT`: __(Deprecated)__ Target port to use for connecting to LocalStack (default: `4566`)
 * `PULUMI_CMD`: Name of the executable Pulumi command on the system PATH (default: `pulumi`)
+* `CONFIG_STRATEGY`: the strategy to handle config merging, if stack config already exists `pulumi-local` will prompt for user input. Possible values are:
+  * `overwrite` (default): pulumi-local will overwrite the stack and replaces it with values necessary with values that are necessary to communicate with LocalStack. This strategy is equivalent of the legacy behaviour.
+  * `override`: generates a temporary config file from the current stack config and overrides it's values, after run this file will be deleted. The name of the file is generated from the `LS_STACK_NAME` variable.
+  * `separate`: creates a separate stack with the stack name set in the `LS_STACK_NAME` env variable.
+* `LS_STACK_NAME`: the stack name to use when the config file generated either with the `override` and `separate` strategy.
+* `DRY_RUN`: only usable with `CONFIG_STRATEGY=override`, as a result the created temporary stack config is not deleted.
+* `NON_INTERACTIVE`: starts a non-interactive session where all user prompts are automatically accepted
 
 ## Deploying to AWS
 Use your preferred Pulumi backend. https://www.pulumi.com/docs/concepts/state/#deciding-on-a-state-backend
@@ -71,6 +78,7 @@ Change the `pulumilocal` command in the instructions above to `pulumi`.
 
 ## Change Log
 
+* v1.3.0: Add config merging strategies, dry-run and non-interactive runs.
 * v1.2.2: Fix project URL in package metadata
 * v1.2.1: Add support for AWS_ENDPOINT_URL env variable
 * v1.2.0: Added dynamic endpoint generation and tests

--- a/README.md
+++ b/README.md
@@ -64,13 +64,18 @@ You can configure the following environment variables:
 * `LOCALSTACK_HOSTNAME`: __(Deprecated)__ Target host to use for connecting to LocalStack (default: `localhost`)
 * `EDGE_PORT`: __(Deprecated)__ Target port to use for connecting to LocalStack (default: `4566`)
 * `PULUMI_CMD`: Name of the executable Pulumi command on the system PATH (default: `pulumi`)
-* `CONFIG_STRATEGY`: the strategy to handle config merging, if stack config already exists `pulumi-local` will prompt for user input. Possible values are:
-  * `overwrite` (default): pulumi-local will overwrite the stack and replaces it with values necessary with values that are necessary to communicate with LocalStack. This strategy is equivalent of the legacy behaviour.
+* `CONFIG_STRATEGY`: the strategy to handle config merging. If stack config already exists `pulumi-local` will prompt for user input. Possible values are:
+  * `overwrite` (default): pulumi-local will overwrite the stack's config and replaces it with values necessary to communicate with LocalStack. This strategy is equivalent of the legacy behaviour.
   * `override`: generates a temporary config file from the current stack config and overrides it's values, after run this file will be deleted. The name of the file is generated from the `LS_STACK_NAME` variable.
   * `separate`: creates a separate stack with the stack name set in the `LS_STACK_NAME` env variable.
+> [!NOTE]
+> The fall through to the default strategy with a misconfigured or missing `CONFIG_STRATEGY` environment variable will be deprecated by the next `pulumi-local` version.
 * `LS_STACK_NAME`: the stack name to use when the config file generated either with the `override` and `separate` strategy.
 * `DRY_RUN`: only usable with `CONFIG_STRATEGY=override`, as a result the created temporary stack config is not deleted.
 * `NON_INTERACTIVE`: starts a non-interactive session where all user prompts are automatically accepted
+
+> [!WARNING]
+> Using the `DRY_RUN` and `NON_INTERACTIVE` flags together changes the stack configuration without confirmation prompt. Use with caution!
 
 ## Deploying to AWS
 Use your preferred Pulumi backend. https://www.pulumi.com/docs/concepts/state/#deciding-on-a-state-backend

--- a/bin/pulumilocal
+++ b/bin/pulumilocal
@@ -44,11 +44,11 @@ def get_stack_config_file_path(args: argparse.Namespace) -> str:
     """Determine the path under which the stack config file should exist"""
     if args.config_file and os.path.isabs(args.config_file):
         return args.config_file
-    
+
     base_dir = args.cwd or "."
     stack_config = args.config_file or f"Pulumi.{args.stack}.yaml"
-    
-    return os.path.join(os.path.abspath(base_dir), stack_config)
+
+    return os.path.join(base_dir, stack_config)
 
 
 def check_stack_config_file(stack_config: str) -> None:
@@ -174,7 +174,7 @@ def main():
                         action="store_true",
                         required=False)
     args, _ = parser.parse_known_args()
-    
+
     if NON_INTERACTIVE:
         args.non_interactive = True
 
@@ -191,9 +191,10 @@ def main():
         print("Updating this Stack with LocalStack config")
         set_localstack_pulumi_config(args)
     # Run the original command
-    if args.non_interactive and "--non-interactive" not in sys.argv:
-        sys.argv.append("--non-interactive")
-    return os.execvp(PULUMI_CMD, sys.argv)
+    if DRY_RUN:
+        if args.non_interactive and "--non-interactive" not in sys.argv:
+            sys.argv.append("--non-interactive")
+        return os.execvp(PULUMI_CMD, sys.argv)
 
 
 if __name__ == "__main__":

--- a/bin/pulumilocal
+++ b/bin/pulumilocal
@@ -35,6 +35,12 @@ EDGE_PORT = int(urlparse(os.environ.get("AWS_ENDPOINT_URL")).port or os.environ.
 USE_SSL = str(os.environ.get("USE_SSL")).strip().lower() in TRUE_STRINGS
 DRY_RUN = str(os.environ.get("DRY_RUN")).strip().lower() in TRUE_STRINGS
 NON_INTERACTIVE = str(os.environ.get("NON_INTERACTIVE")).strip().lower() in TRUE_STRINGS
+PROXIED_CMDS = (
+    "up",
+    "destroy",
+    "preview",
+    "cancel"
+)
 
 
 # Do not allow PULUMI_CMD env var to be set to pulumilocal as this causes an error
@@ -214,7 +220,7 @@ def main():
         print(f'Config strategy is not recognised. Falling back to default ("{DEFAULT_CONFIG_STRATEGY}").')
 
     # If this is a pulumi deployment command, update the stack with LocalStack AWS config
-    if args.command in ["up", "destroy", "preview", "cancel"]:
+    if args.command in PROXIED_CMDS:
         if not args.stack:
             try:
                 args.stack = subprocess.run(
@@ -248,7 +254,9 @@ def main():
         print("Updating this Stack with LocalStack config")
         set_localstack_pulumi_config(args)
     # Run the original command
-    if not DRY_RUN:
+    if DRY_RUN and args.command in PROXIED_CMDS:
+        print("Dry run detected, skipping Pulumi invokation. Terminating.")
+    else:
         if args.non_interactive and "--non-interactive" not in sys.argv:
             sys.argv.append("--non-interactive")
         try:
@@ -256,10 +264,8 @@ def main():
         except subprocess.CalledProcessError as e:
             print(e.stderr.decode("utf-8"))
         finally:
-            if CONFIG_STRATEGY == "override":
+            if CONFIG_STRATEGY == "override" and args.command in PROXIED_CMDS:
                 os.remove(args.config_file)
-    else:
-        print("Dry run detected, skipping Pulumi invokation. Terminating.")
 
 
 if __name__ == "__main__":

--- a/bin/pulumilocal
+++ b/bin/pulumilocal
@@ -14,6 +14,7 @@ import argparse
 import subprocess
 import json
 from typing import Dict, List
+from shutil import copyfile
 from urllib.parse import urlparse
 
 # for local testing
@@ -23,9 +24,10 @@ if os.path.isdir(os.path.join(PARENT_FOLDER, ".venv")):
 
 # define global constants
 TRUE_STRINGS = ["1", "true"]
-CONFIG_STRATEGIES = ("overwrite", "merge", "separate")
+CONFIG_STRATEGIES = ("overwrite", "override", "separation")
 DEFAULT_CONFIG_STRATEGY = "overwrite"
-CONFIG_STRATEGY = os.environ.get("CONFIG_STRATEGY") or DEFAULT_CONFIG_STRATEGY
+LOCAL_STACK_NAME = os.environ.get("LOCAL_STACK_NAME") or "localstack"
+CONFIG_STRATEGY = os.environ.get("CONFIG_STRATEGY") if os.environ.get("CONFIG_STRATEGY") in CONFIG_STRATEGIES else DEFAULT_CONFIG_STRATEGY
 PULUMI_CMD = os.environ.get("PULUMI_CMD") or "pulumi"
 AWS_ENDPOINT_URL = os.environ.get("AWS_ENDPOINT_URL")
 LOCALSTACK_HOSTNAME = urlparse(os.environ.get("AWS_ENDPOINT_URL")).hostname or os.environ.get("LOCALSTACK_HOSTNAME") or "localhost"
@@ -38,6 +40,12 @@ NON_INTERACTIVE = str(os.environ.get("NON_INTERACTIVE")).strip().lower() in TRUE
 # Do not allow PULUMI_CMD env var to be set to pulumilocal as this causes an error
 if PULUMI_CMD == "pulumilocal":
     PULUMI_CMD = "pulumi"
+
+
+def deactivate_access_key(access_key: str) -> str:
+    """Safe guarding user from accidental live credential usage by deactivating access key IDs.
+        See more: https://docs.localstack.cloud/references/credentials/"""
+    return "L" + access_key[1:] if access_key[0] == "A" else access_key
 
 
 def get_stack_config_file_path(args: argparse.Namespace) -> str:
@@ -128,11 +136,10 @@ def set_localstack_pulumi_config(args: argparse.Namespace):
     if args.config_file:
         config_args.append("--config-file")
         config_args.append(args.config_file)
-    config_args.append("set-all")
 
     # Resetting all endpoints
     try:
-        subprocess.run(executable=PULUMI_CMD, args=(config_args + set_config_options(is_path=True, **{"aws:endpoints": ""})), env=os.environ, stdout=subprocess.PIPE, check=True)
+        subprocess.run(executable=PULUMI_CMD, args=(config_args + ["set-all"] + set_config_options(is_path=True, **{"aws:endpoints": ""})), env=os.environ, stdout=subprocess.PIPE, check=True)
     except subprocess.CalledProcessError as e:
         exit(e.returncode)
     except FileNotFoundError as e:
@@ -147,6 +154,27 @@ def set_localstack_pulumi_config(args: argparse.Namespace):
         "aws:skipCredentialsValidation": "true",
         "aws:skipRequestingAccountId": "true",
     }
+
+    tmp = DEFAULT_CONFIG_ARGS.copy()
+    for k in DEFAULT_CONFIG_ARGS:
+        try:
+            output = subprocess.run(
+                executable=PULUMI_CMD,
+                args=(config_args + ["get", k]),
+                env=os.environ,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.DEVNULL,
+                check=True).stdout.decode("utf-8").strip("\n")
+        except subprocess.CalledProcessError:
+            pass
+        else:
+            if k == "aws:accessKey":
+                tmp[k] = deactivate_access_key(output)
+            elif k != "aws:secretKey":
+                del tmp[k]
+    DEFAULT_CONFIG_ARGS = tmp
+
+    config_args.append("set-all")
     config_args.extend(set_config_options(**DEFAULT_CONFIG_ARGS))
     for idx, service in enumerate(generate_service_endpoints(args)):
         config_args.extend(set_config_options(is_path=True, **{f"aws:endpoints[{idx}].{service}": service_url}))
@@ -181,6 +209,10 @@ def main():
     if not args.cwd:
         args.cwd = "."
 
+    if os.environ.get("CONFIG_STRATEGY") not in CONFIG_STRATEGIES:
+        print(f"Config strategy: {os.environ.get('CONFIG_STRATEGY')}")
+        print(f'Config strategy is not recognised. Falling back to default ("{DEFAULT_CONFIG_STRATEGY}").')
+
     # If this is a pulumi deployment command, update the stack with LocalStack AWS config
     if args.command in ["up", "destroy", "preview", "cancel"]:
         if not args.stack:
@@ -194,15 +226,40 @@ def main():
             except (subprocess.CalledProcessError) as e:
                 print(e.stderr.decode("utf-8"))
                 exit(1)
+        config_file_path = get_stack_config_file_path(args)
         if not args.non_interactive:
-            check_stack_config_file(get_stack_config_file_path(args))
+            check_stack_config_file(config_file_path)
+        if CONFIG_STRATEGY == "override":
+            override_config_file = os.path.join(os.path.dirname(config_file_path), f"Pulumi.{LOCAL_STACK_NAME}.yaml")
+            copyfile(src=config_file_path, dst=override_config_file)
+            args.config_file = override_config_file
+        elif CONFIG_STRATEGY == "separation":
+            print(f"Creating stack {LOCAL_STACK_NAME}, if not existing...")
+            subprocess.run(
+                [PULUMI_CMD, "stack", "init", "--non-interactive", "-s", LOCAL_STACK_NAME, "-C", args.cwd],
+                env=os.environ,
+                check=False,
+                stderr=subprocess.DEVNULL
+            )
+            override_config_file = os.path.join(os.path.dirname(config_file_path), f"Pulumi.{LOCAL_STACK_NAME}.yaml")
+            if override_config_file != config_file_path:
+                copyfile(src=config_file_path, dst=override_config_file)
+                args.config_file = override_config_file
         print("Updating this Stack with LocalStack config")
         set_localstack_pulumi_config(args)
     # Run the original command
     if not DRY_RUN:
         if args.non_interactive and "--non-interactive" not in sys.argv:
             sys.argv.append("--non-interactive")
-        return os.execvp(PULUMI_CMD, sys.argv)
+        try:
+            subprocess.run(executable=PULUMI_CMD, args=sys.argv, check=True)
+        except subprocess.CalledProcessError as e:
+            print(e.stderr.decode("utf-8"))
+        finally:
+            if CONFIG_STRATEGY == "override":
+                os.remove(args.config_file)
+    else:
+        print("Dry run detected, skipping Pulumi invokation. Terminating.")
 
 
 if __name__ == "__main__":

--- a/bin/pulumilocal
+++ b/bin/pulumilocal
@@ -76,7 +76,7 @@ def check_stack_config_file(stack_config: str) -> None:
             print("\tOnly 'yes' will be accepted to approve.")
             if input("\tEnter a value: ") == "yes":
                 return
-        print(err_msg)
+        print(err_msg, file=sys.stderr)
         exit(1)
 
 
@@ -149,7 +149,7 @@ def set_localstack_pulumi_config(args: argparse.Namespace):
     except subprocess.CalledProcessError as e:
         exit(e.returncode)
     except FileNotFoundError as e:
-        print(e)
+        print(e, file=sys.stderr)
         exit(e.errno)
 
     DEFAULT_CONFIG_ARGS = {
@@ -230,7 +230,7 @@ def main():
                     capture_output=True
                 ).stdout.decode("utf-8").strip("\n")
             except (subprocess.CalledProcessError) as e:
-                print(e.stderr.decode("utf-8"))
+                print(e.stderr.decode("utf-8"), file=sys.stderr)
                 exit(1)
         config_file_path = get_stack_config_file_path(args)
         if not args.non_interactive:
@@ -262,7 +262,7 @@ def main():
         try:
             subprocess.run(executable=PULUMI_CMD, args=sys.argv, check=True)
         except subprocess.CalledProcessError as e:
-            print(e.stderr.decode("utf-8"))
+            print(e.stderr.decode("utf-8"), file=sys.stderr)
         finally:
             if CONFIG_STRATEGY == "override" and args.command in PROXIED_CMDS:
                 os.remove(args.config_file)

--- a/bin/pulumilocal
+++ b/bin/pulumilocal
@@ -32,9 +32,9 @@ PULUMI_CMD = os.environ.get("PULUMI_CMD") or "pulumi"
 AWS_ENDPOINT_URL = os.environ.get("AWS_ENDPOINT_URL")
 LOCALSTACK_HOSTNAME = urlparse(os.environ.get("AWS_ENDPOINT_URL")).hostname or os.environ.get("LOCALSTACK_HOSTNAME") or "localhost"
 EDGE_PORT = int(urlparse(os.environ.get("AWS_ENDPOINT_URL")).port or os.environ.get("EDGE_PORT") or 4566)
-USE_SSL = str(os.environ.get("USE_SSL")).strip().lower() in TRUE_STRINGS
-DRY_RUN = str(os.environ.get("DRY_RUN")).strip().lower() in TRUE_STRINGS
-NON_INTERACTIVE = str(os.environ.get("NON_INTERACTIVE")).strip().lower() in TRUE_STRINGS
+USE_SSL = str(os.environ.get("USE_SSL","")).strip().lower() in TRUE_STRINGS
+DRY_RUN = str(os.environ.get("DRY_RUN","")).strip().lower() in TRUE_STRINGS
+NON_INTERACTIVE = str(os.environ.get("NON_INTERACTIVE","")).strip().lower() in TRUE_STRINGS
 PROXIED_CMDS = (
     "up",
     "destroy",

--- a/bin/pulumilocal
+++ b/bin/pulumilocal
@@ -32,9 +32,9 @@ PULUMI_CMD = os.environ.get("PULUMI_CMD") or "pulumi"
 AWS_ENDPOINT_URL = os.environ.get("AWS_ENDPOINT_URL")
 LOCALSTACK_HOSTNAME = urlparse(os.environ.get("AWS_ENDPOINT_URL")).hostname or os.environ.get("LOCALSTACK_HOSTNAME") or "localhost"
 EDGE_PORT = int(urlparse(os.environ.get("AWS_ENDPOINT_URL")).port or os.environ.get("EDGE_PORT") or 4566)
-USE_SSL = str(os.environ.get("USE_SSL","")).strip().lower() in TRUE_STRINGS
-DRY_RUN = str(os.environ.get("DRY_RUN","")).strip().lower() in TRUE_STRINGS
-NON_INTERACTIVE = str(os.environ.get("NON_INTERACTIVE","")).strip().lower() in TRUE_STRINGS
+USE_SSL = str(os.environ.get("USE_SSL", "")).strip().lower() in TRUE_STRINGS
+DRY_RUN = str(os.environ.get("DRY_RUN", "")).strip().lower() in TRUE_STRINGS
+NON_INTERACTIVE = str(os.environ.get("NON_INTERACTIVE", "")).strip().lower() in TRUE_STRINGS
 PROXIED_CMDS = (
     "up",
     "destroy",
@@ -145,7 +145,12 @@ def set_localstack_pulumi_config(args: argparse.Namespace):
 
     # Resetting all endpoints
     try:
-        subprocess.run(executable=PULUMI_CMD, args=(config_args + ["set-all"] + set_config_options(is_path=True, **{"aws:endpoints": ""})), stdout=subprocess.PIPE, check=True)
+        subprocess.run(
+            executable=PULUMI_CMD,
+            args=(config_args + ["set-all"] + set_config_options(is_path=True, **{"aws:endpoints": ""})),
+            stdout=subprocess.PIPE,
+            check=True
+        )
     except subprocess.CalledProcessError as e:
         exit(e.returncode)
     except FileNotFoundError as e:

--- a/bin/pulumilocal
+++ b/bin/pulumilocal
@@ -23,15 +23,44 @@ if os.path.isdir(os.path.join(PARENT_FOLDER, ".venv")):
 
 # define global constants
 TRUE_STRINGS = ["1", "true"]
+DEFAULT_CONFIG_STRATEGY = "overwrite"
+CONFIG_STRATEGIES = ("overwrite", "merge", "separate")
 PULUMI_CMD = os.environ.get("PULUMI_CMD") or "pulumi"
 AWS_ENDPOINT_URL = os.environ.get("AWS_ENDPOINT_URL")
 LOCALSTACK_HOSTNAME = urlparse(os.environ.get("AWS_ENDPOINT_URL")).hostname or os.environ.get("LOCALSTACK_HOSTNAME") or "localhost"
 EDGE_PORT = int(urlparse(os.environ.get("AWS_ENDPOINT_URL")).port or os.environ.get("EDGE_PORT") or 4566)
 USE_SSL = str(os.environ.get("USE_SSL")).strip().lower() in TRUE_STRINGS
+CONFIG_STRATEGY = os.environ.get("CONFIG_STRATEGY") or DEFAULT_CONFIG_STRATEGY
 
 # Do not allow PULUMI_CMD env var to be set to pulumilocal as this causes an error
 if PULUMI_CMD == "pulumilocal":
     PULUMI_CMD = "pulumi"
+
+
+def get_stack_config_file_path(args: argparse.Namespace) -> str:
+    """Determine the path under which the stack config file should exist"""
+    if args.config_file and os.path.isabs(args.config_file):
+        return args.config_file
+    
+    base_dir = args.cwd or "."
+    stack_config = args.config_file or f"Pulumi.{args.stack}.yaml"
+    
+    return os.path.join(os.path.abspath(base_dir), stack_config)
+
+
+def check_stack_config_file(stack_config: str) -> None:
+    """Checks stack config file existance"""
+    if os.path.exists(stack_config):
+        msg = f"Stack config file {stack_config} already exists"
+        err_msg = msg + " - please delete it first, exiting..."
+        if CONFIG_STRATEGY == "overwrite":
+            msg += ". File will be overwritten."
+            print(msg)
+            print("\tOnly 'yes' will be accepted to approve.")
+            if input("\tEnter a value: ") == "yes":
+                return
+        print(err_msg)
+        exit(1)
 
 
 def generate_service_endpoints(args) -> Dict:
@@ -93,6 +122,9 @@ def set_localstack_pulumi_config(args: argparse.Namespace):
     if args.cwd:
         config_args.append("--cwd")
         config_args.append(args.cwd)
+    if args.config_file:
+        config_args.append("--config-file")
+        config_args.append(args.config_file)
     config_args.append("set-all")
 
     # Resetting all endpoints
@@ -132,10 +164,20 @@ def main():
     parser.add_argument("-C", "--cwd", help="run in this directory",
                         required=False,
                         type=str)
+    parser.add_argument("--config-file", help="pulumi stack config to use",
+                        required=False,
+                        type=str)
     args, _ = parser.parse_known_args()
 
     # If this is a pulumi deployment command, update the stack with LocalStack AWS config
     if args.command in ["up", "destroy", "preview", "cancel"]:
+        if not args.stack:
+            try:
+                args.stack = subprocess.run([PULUMI_CMD, "stack", "--show-name", "--non-interactive"], env=os.environ, check=True, capture_output=True).stdout.decode("utf-8").strip("\n")
+            except (subprocess.CalledProcessError) as e:
+                print(e.stderr.decode("utf-8"))
+                exit(1)
+        check_stack_config_file(get_stack_config_file_path(args))
         print("Updating this Stack with LocalStack config")
         set_localstack_pulumi_config(args)
     # Run the original command

--- a/bin/pulumilocal
+++ b/bin/pulumilocal
@@ -178,11 +178,19 @@ def main():
     if NON_INTERACTIVE:
         args.non_interactive = True
 
+    if not args.cwd:
+        args.cwd = "."
+
     # If this is a pulumi deployment command, update the stack with LocalStack AWS config
     if args.command in ["up", "destroy", "preview", "cancel"]:
         if not args.stack:
             try:
-                args.stack = subprocess.run([PULUMI_CMD, "stack", "--show-name", "--non-interactive"], env=os.environ, check=True, capture_output=True).stdout.decode("utf-8").strip("\n")
+                args.stack = subprocess.run(
+                    [PULUMI_CMD, "stack", "--show-name", "--non-interactive", "-C", args.cwd],
+                    env=os.environ,
+                    check=True,
+                    capture_output=True
+                ).stdout.decode("utf-8").strip("\n")
             except (subprocess.CalledProcessError) as e:
                 print(e.stderr.decode("utf-8"))
                 exit(1)
@@ -191,7 +199,7 @@ def main():
         print("Updating this Stack with LocalStack config")
         set_localstack_pulumi_config(args)
     # Run the original command
-    if DRY_RUN:
+    if not DRY_RUN:
         if args.non_interactive and "--non-interactive" not in sys.argv:
             sys.argv.append("--non-interactive")
         return os.execvp(PULUMI_CMD, sys.argv)

--- a/bin/pulumilocal
+++ b/bin/pulumilocal
@@ -26,7 +26,7 @@ if os.path.isdir(os.path.join(PARENT_FOLDER, ".venv")):
 TRUE_STRINGS = ["1", "true"]
 CONFIG_STRATEGIES = ("overwrite", "override", "separation")
 DEFAULT_CONFIG_STRATEGY = "overwrite"
-LOCAL_STACK_NAME = os.environ.get("LOCAL_STACK_NAME") or "localstack"
+LS_STACK_NAME = os.environ.get("LS_STACK_NAME") or "localstack"
 CONFIG_STRATEGY = os.environ.get("CONFIG_STRATEGY") if os.environ.get("CONFIG_STRATEGY") in CONFIG_STRATEGIES else DEFAULT_CONFIG_STRATEGY
 PULUMI_CMD = os.environ.get("PULUMI_CMD") or "pulumi"
 AWS_ENDPOINT_URL = os.environ.get("AWS_ENDPOINT_URL")
@@ -236,18 +236,17 @@ def main():
         if not args.non_interactive:
             check_stack_config_file(config_file_path)
         if CONFIG_STRATEGY == "override":
-            override_config_file = os.path.join(os.path.dirname(config_file_path), f"Pulumi.{LOCAL_STACK_NAME}.yaml")
+            override_config_file = os.path.join(os.path.dirname(config_file_path), f"Pulumi.{LS_STACK_NAME}.yaml")
             copyfile(src=config_file_path, dst=override_config_file)
             args.config_file = override_config_file
         elif CONFIG_STRATEGY == "separation":
-            print(f"Creating stack {LOCAL_STACK_NAME}, if not existing...")
+            print(f"Creating stack {LS_STACK_NAME}, if not existing...")
             subprocess.run(
-                [PULUMI_CMD, "stack", "init", "--non-interactive", "-s", LOCAL_STACK_NAME, "-C", args.cwd],
-                env=os.environ,
+                [PULUMI_CMD, "stack", "init", "--non-interactive", "-s", LS_STACK_NAME, "-C", args.cwd],
                 check=False,
                 stderr=subprocess.DEVNULL
             )
-            override_config_file = os.path.join(os.path.dirname(config_file_path), f"Pulumi.{LOCAL_STACK_NAME}.yaml")
+            override_config_file = os.path.join(os.path.dirname(config_file_path), f"Pulumi.{LS_STACK_NAME}.yaml")
             if override_config_file != config_file_path:
                 copyfile(src=config_file_path, dst=override_config_file)
                 args.config_file = override_config_file

--- a/bin/pulumilocal
+++ b/bin/pulumilocal
@@ -23,14 +23,17 @@ if os.path.isdir(os.path.join(PARENT_FOLDER, ".venv")):
 
 # define global constants
 TRUE_STRINGS = ["1", "true"]
-DEFAULT_CONFIG_STRATEGY = "overwrite"
 CONFIG_STRATEGIES = ("overwrite", "merge", "separate")
+DEFAULT_CONFIG_STRATEGY = "overwrite"
+CONFIG_STRATEGY = os.environ.get("CONFIG_STRATEGY") or DEFAULT_CONFIG_STRATEGY
 PULUMI_CMD = os.environ.get("PULUMI_CMD") or "pulumi"
 AWS_ENDPOINT_URL = os.environ.get("AWS_ENDPOINT_URL")
 LOCALSTACK_HOSTNAME = urlparse(os.environ.get("AWS_ENDPOINT_URL")).hostname or os.environ.get("LOCALSTACK_HOSTNAME") or "localhost"
 EDGE_PORT = int(urlparse(os.environ.get("AWS_ENDPOINT_URL")).port or os.environ.get("EDGE_PORT") or 4566)
 USE_SSL = str(os.environ.get("USE_SSL")).strip().lower() in TRUE_STRINGS
-CONFIG_STRATEGY = os.environ.get("CONFIG_STRATEGY") or DEFAULT_CONFIG_STRATEGY
+DRY_RUN = str(os.environ.get("DRY_RUN")).strip().lower() in TRUE_STRINGS
+NON_INTERACTIVE = str(os.environ.get("NON_INTERACTIVE")).strip().lower() in TRUE_STRINGS
+
 
 # Do not allow PULUMI_CMD env var to be set to pulumilocal as this causes an error
 if PULUMI_CMD == "pulumilocal":
@@ -156,18 +159,24 @@ def set_localstack_pulumi_config(args: argparse.Namespace):
 def main():
     # Parse arguments from call to pulumi CLI that set the stack name and directory
     parser = argparse.ArgumentParser(add_help=False)
-    parser.add_argument("command", help="pulumi primary command",
+    parser.add_argument("command", help="Pulumi command",
                         type=str)
-    parser.add_argument("-s", "--stack", help="pulumi stack name",
+    parser.add_argument("-s", "--stack", help="The name of the stack to operate on. Defaults to the current stack",
                         required=False,
                         type=str)
-    parser.add_argument("-C", "--cwd", help="run in this directory",
+    parser.add_argument("-C", "--cwd", help="Run pulumi as if it had been started in another directory",
                         required=False,
                         type=str)
-    parser.add_argument("--config-file", help="pulumi stack config to use",
+    parser.add_argument("--config-file", help="Use the configuration values in the specified file rather than detecting the file name",
                         required=False,
                         type=str)
+    parser.add_argument("--non-interactive", help="Disable interactive mode for all commands",
+                        action="store_true",
+                        required=False)
     args, _ = parser.parse_known_args()
+    
+    if NON_INTERACTIVE:
+        args.non_interactive = True
 
     # If this is a pulumi deployment command, update the stack with LocalStack AWS config
     if args.command in ["up", "destroy", "preview", "cancel"]:
@@ -177,10 +186,13 @@ def main():
             except (subprocess.CalledProcessError) as e:
                 print(e.stderr.decode("utf-8"))
                 exit(1)
-        check_stack_config_file(get_stack_config_file_path(args))
+        if not args.non_interactive:
+            check_stack_config_file(get_stack_config_file_path(args))
         print("Updating this Stack with LocalStack config")
         set_localstack_pulumi_config(args)
     # Run the original command
+    if args.non_interactive and "--non-interactive" not in sys.argv:
+        sys.argv.append("--non-interactive")
     return os.execvp(PULUMI_CMD, sys.argv)
 
 

--- a/bin/pulumilocal
+++ b/bin/pulumilocal
@@ -87,7 +87,7 @@ def generate_service_endpoints(args) -> Dict:
     if args.cwd:
         cmd_args.extend(("--cwd", args.cwd))
     try:
-        sp = subprocess.run(executable=PULUMI_CMD, args=cmd_args, env=os.environ, stdout=subprocess.PIPE, check=True)
+        sp = subprocess.run(executable=PULUMI_CMD, args=cmd_args, stdout=subprocess.PIPE, check=True)
     except subprocess.CalledProcessError as e:
         exit(e.returncode)
     plugins = json.loads(sp.stdout.decode("utf-8")).get("plugins")
@@ -97,7 +97,7 @@ def generate_service_endpoints(args) -> Dict:
         version = ""
     config_args = [PULUMI_CMD, "package", "get-schema", f"aws{version}"]
     try:
-        sp = subprocess.run(executable=PULUMI_CMD, args=config_args, env=os.environ, stdout=subprocess.PIPE, check=True)
+        sp = subprocess.run(executable=PULUMI_CMD, args=config_args, stdout=subprocess.PIPE, check=True)
     except subprocess.CalledProcessError as e:
         exit(e.returncode)
     schema = json.loads(sp.stdout.decode("utf-8"))
@@ -145,7 +145,7 @@ def set_localstack_pulumi_config(args: argparse.Namespace):
 
     # Resetting all endpoints
     try:
-        subprocess.run(executable=PULUMI_CMD, args=(config_args + ["set-all"] + set_config_options(is_path=True, **{"aws:endpoints": ""})), env=os.environ, stdout=subprocess.PIPE, check=True)
+        subprocess.run(executable=PULUMI_CMD, args=(config_args + ["set-all"] + set_config_options(is_path=True, **{"aws:endpoints": ""})), stdout=subprocess.PIPE, check=True)
     except subprocess.CalledProcessError as e:
         exit(e.returncode)
     except FileNotFoundError as e:
@@ -167,7 +167,6 @@ def set_localstack_pulumi_config(args: argparse.Namespace):
             output = subprocess.run(
                 executable=PULUMI_CMD,
                 args=(config_args + ["get", k]),
-                env=os.environ,
                 stdout=subprocess.PIPE,
                 stderr=subprocess.DEVNULL,
                 check=True).stdout.decode("utf-8").strip("\n")
@@ -185,7 +184,7 @@ def set_localstack_pulumi_config(args: argparse.Namespace):
     for idx, service in enumerate(generate_service_endpoints(args)):
         config_args.extend(set_config_options(is_path=True, **{f"aws:endpoints[{idx}].{service}": service_url}))
     try:
-        subprocess.run(executable=PULUMI_CMD, args=config_args, env=os.environ, stdout=subprocess.PIPE, check=True)
+        subprocess.run(executable=PULUMI_CMD, args=config_args, stdout=subprocess.PIPE, check=True)
     except subprocess.CalledProcessError as e:
         exit(e.returncode)
 
@@ -225,7 +224,6 @@ def main():
             try:
                 args.stack = subprocess.run(
                     [PULUMI_CMD, "stack", "--show-name", "--non-interactive", "-C", args.cwd],
-                    env=os.environ,
                     check=True,
                     capture_output=True
                 ).stdout.decode("utf-8").strip("\n")

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = pulumi-local
-version = 1.2.2
+version = 1.3.0
 url = https://github.com/localstack/pulumi-local
 author = LocalStack Team
 author_email = info@localstack.cloud
@@ -14,6 +14,7 @@ classifiers =
     Programming Language :: Python :: 3.9
     Programming Language :: Python :: 3.10
     Programming Language :: Python :: 3.11
+    Programming Language :: Python :: 3.12
     License :: OSI Approved :: Apache Software License
     Topic :: Software Development :: Testing
 

--- a/tests/test_apply.py
+++ b/tests/test_apply.py
@@ -62,9 +62,13 @@ def test_config_strategy(config_strategy: str):
         local_config = expected_result[1]
         assert os.path.exists(stack_config) == should_exists
         if should_exists and local_config:
-            assert run([PULUMILOCAL_BIN, "config", "get", "aws:secretKey", "--cwd", tmp_dir, "--config-file", stack_config], env={**os.environ, **env_vars})[1].split("\n")[-2] == "test"
+            run_result = run([PULUMILOCAL_BIN, "config", "get", "aws:secretKey", "--cwd", tmp_dir, "--config-file", stack_config], env={**os.environ, **env_vars})
+            print(run_result)
+            assert run_result[1].strip("\n").split("\n")[-1] == "test"
         elif should_exists and not local_config:
-            assert run([PULUMILOCAL_BIN, "config", "get", "aws:secretKey", "--cwd", tmp_dir, "--config-file", stack_config], env={**os.environ, **env_vars})[0]
+            run_result = run([PULUMILOCAL_BIN, "config", "get", "aws:secretKey", "--cwd", tmp_dir, "--config-file", stack_config], env={**os.environ, **env_vars})
+            print(run_result)
+            assert run_result[0]
     rmtree(tmp_dir)
 
 ###

--- a/tests/test_apply.py
+++ b/tests/test_apply.py
@@ -37,8 +37,9 @@ def test_config_strategy(config_strategy: str):
     env_vars = {
         "PULUMI_CONFIG_PASSPHRASE": "localstack",
         "NON_INTERACTIVE": "1",
-        "CONFIG_STRATEGY": config_strategy,
     }
+    if config_strategy:
+        env_vars.update({"CONFIG_STRATEGY": config_strategy})
     tmp_dir = create_dummy_stack(env_vars=env_vars)
     match config_strategy:
         case "override":

--- a/tests/test_apply.py
+++ b/tests/test_apply.py
@@ -31,9 +31,10 @@ def test_provisioning_outside_project():
     bucket_name = short_uid()
     assert "error: no Pulumi.yaml project file found" in create_test_bucket(bucket_name, should_fail=True)
 
+
 @pytest.mark.parametrize("config_strategy", ["override", "overwrite", "separation", "separate", ""])
 def test_config_strategy(config_strategy: str):
-    env_vars={
+    env_vars = {
         "PULUMI_CONFIG_PASSPHRASE": "localstack",
         "NON_INTERACTIVE": "1",
         "CONFIG_STRATEGY": config_strategy,
@@ -61,9 +62,9 @@ def test_config_strategy(config_strategy: str):
         local_config = expected_result[1]
         assert os.path.exists(stack_config) == should_exists
         if should_exists and local_config:
-            assert run([PULUMILOCAL_BIN, "config", "get", "aws:secretKey", "--cwd", tmp_dir, "--config-file", stack_config],env={**os.environ, **env_vars})[1].split("\n")[-2] == "test"
+            assert run([PULUMILOCAL_BIN, "config", "get", "aws:secretKey", "--cwd", tmp_dir, "--config-file", stack_config], env={**os.environ, **env_vars})[1].split("\n")[-2] == "test"
         elif should_exists and not local_config:
-            assert run([PULUMILOCAL_BIN, "config", "get", "aws:secretKey", "--cwd", tmp_dir, "--config-file", stack_config],env={**os.environ, **env_vars})[0]
+            assert run([PULUMILOCAL_BIN, "config", "get", "aws:secretKey", "--cwd", tmp_dir, "--config-file", stack_config], env={**os.environ, **env_vars})[0]
     rmtree(tmp_dir)
 
 ###

--- a/tests/test_apply.py
+++ b/tests/test_apply.py
@@ -10,7 +10,7 @@ from shutil import rmtree
 THIS_PATH = os.path.abspath(os.path.dirname(__file__))
 ROOT_PATH = os.path.join(THIS_PATH, "..")
 PULUMILOCAL_BIN = os.path.join(ROOT_PATH, "bin", "pulumilocal")
-LOCALSTACK_ENDPOINT = "http://localhost:4566"
+LOCALSTACK_ENDPOINT = "http://localhost.localstack.cloud:4566"
 
 
 @pytest.mark.parametrize("package_version", ["5.42.0", "latest"])

--- a/tests/test_apply.py
+++ b/tests/test_apply.py
@@ -91,7 +91,7 @@ export const bucketName = bucket.id;
         version=version,
         select_stack=select_stack,
         select_cwd=select_cwd,
-        env_vars={"PULUMI_CONFIG_PASSPHRASE": "localstack"},
+        env_vars={"PULUMI_CONFIG_PASSPHRASE": "localstack", "NON_INTERACTIVE": "1"},
         should_fail=should_fail,
     )
 

--- a/tests/test_apply.py
+++ b/tests/test_apply.py
@@ -51,7 +51,7 @@ def deploy_pulumi_script(script: str, version: str, select_stack: bool, select_c
         if out[0]:
             return out[1]
 
-        cmd = ["npm", "install", f"@pulumi/aws{'@'+ version}", "--prefix", temp_dir]
+        cmd = ["npm", "install", f"@pulumi/aws{'@' + version}", "--prefix", temp_dir]
         out = run(cmd, **kwargs)
         if out[0]:
             return out[1]


### PR DESCRIPTION
# Motivation
Config merging and respecting the original stack config is not something currently well supported in `pulumi-local`. To solve this issue, reported on this [issue](#12) too, we'll introduce 3 different config strategies:
- **overwrite strategy (current, default):** this config option simply updates/overwrites the current config with the necessary changes we have to apply for LocalStack
- **override (with dry-run):** this config option temporarily creates a config file by merging the original stacks config with our recommended options and running pulumi commands with it. By setting dry-run, `pulumi-local` creates the config file then terminates without running the command.
- **separation:** copying the currently selected stack's config and creates a new separate stack (by default called localstack, however this is configurable with `DEFAULT_STACK_NAME` env variable)

If any of the config files we'd like to create exists we'll prompt for user input.

## Additional options and features
- `DRY_RUN`: in cases when makes sense creates the config file but terminates after without modifying it, if it finds an already existing one it prompts the user.
- `--non-interactive`/`NON_INTERACTIVE`: the usage of the non-interactive flag is now allowed to suppress any `pulumi-local` prompts for user input.
-  `LOCAL_STACK_NAME`: the name of the LocalStack stack/config file we create, depending on the strategy
- deactivate `aws:accessKey` and `aws:secretKey` options

# Changes
- [x] add user prompt for existing stack configs
- [x] add logic for strategy selection
- [x] add merge strategy, by taking leverage of `--config-file` option of pulumi
- [x] add separate stack strategy by copying the currently selected stack's config and then change to it
- [x] deactivate AWS credentials in the config file
- [x] create tests for strategies