### PR TITLE
Fix pulumi-local execution issues on Windows

### DIFF
--- a/bin/pulumilocal
+++ b/bin/pulumilocal
@@ -17,6 +17,11 @@ from typing import Dict, List
 from shutil import copyfile
 from urllib.parse import urlparse
 from shutil import which
+import functools
+
+
+# force unbuffered print
+print = functools.partial(print, flush=True)
 
 # for local testing
 PARENT_FOLDER = os.path.realpath(os.path.join(os.path.dirname(__file__), ".."))

--- a/bin/pulumilocal
+++ b/bin/pulumilocal
@@ -198,7 +198,7 @@ def main():
     # Parse arguments from call to pulumi CLI that set the stack name and directory
     parser = argparse.ArgumentParser(add_help=False)
     parser.add_argument("command", help="Pulumi command",
-                        type=str)
+                        type=str, nargs="?")
     parser.add_argument("-s", "--stack", help="The name of the stack to operate on. Defaults to the current stack",
                         required=False,
                         type=str)

--- a/bin/pulumilocal
+++ b/bin/pulumilocal
@@ -95,7 +95,7 @@ def generate_service_endpoints(args) -> Dict:
     if args.cwd:
         cmd_args.extend(("--cwd", args.cwd))
     try:
-        sp = subprocess.run(executable=PULUMI_CMD, args=cmd_args, check=True, bufsize=0)
+        sp = subprocess.run(executable=PULUMI_CMD, args=cmd_args, check=True, bufsize=0, capture_output=True)
     except subprocess.CalledProcessError as e:
         exit(e.returncode)
     plugins = json.loads(sp.stdout.decode("utf-8")).get("plugins")
@@ -105,7 +105,7 @@ def generate_service_endpoints(args) -> Dict:
         version = ""
     config_args = [PULUMI_CMD, "package", "get-schema", f"aws{version}"]
     try:
-        sp = subprocess.run(executable=PULUMI_CMD, args=config_args, check=True, bufsize=0)
+        sp = subprocess.run(executable=PULUMI_CMD, args=config_args, check=True, bufsize=0, capture_output=True)
     except subprocess.CalledProcessError as e:
         exit(e.returncode)
     schema = json.loads(sp.stdout.decode("utf-8"))

--- a/bin/pulumilocal
+++ b/bin/pulumilocal
@@ -95,7 +95,7 @@ def generate_service_endpoints(args) -> Dict:
     if args.cwd:
         cmd_args.extend(("--cwd", args.cwd))
     try:
-        sp = subprocess.run(executable=PULUMI_CMD, args=cmd_args, stdout=subprocess.PIPE, check=True)
+        sp = subprocess.run(executable=PULUMI_CMD, args=cmd_args, check=True)
     except subprocess.CalledProcessError as e:
         exit(e.returncode)
     plugins = json.loads(sp.stdout.decode("utf-8")).get("plugins")
@@ -105,7 +105,7 @@ def generate_service_endpoints(args) -> Dict:
         version = ""
     config_args = [PULUMI_CMD, "package", "get-schema", f"aws{version}"]
     try:
-        sp = subprocess.run(executable=PULUMI_CMD, args=config_args, stdout=subprocess.PIPE, check=True)
+        sp = subprocess.run(executable=PULUMI_CMD, args=config_args, check=True)
     except subprocess.CalledProcessError as e:
         exit(e.returncode)
     schema = json.loads(sp.stdout.decode("utf-8"))
@@ -156,7 +156,6 @@ def set_localstack_pulumi_config(args: argparse.Namespace):
         subprocess.run(
             executable=PULUMI_CMD,
             args=(config_args + ["set-all"] + set_config_options(is_path=True, **{"aws:endpoints": ""})),
-            stdout=subprocess.PIPE,
             check=True
         )
     except subprocess.CalledProcessError as e:
@@ -180,7 +179,6 @@ def set_localstack_pulumi_config(args: argparse.Namespace):
             output = subprocess.run(
                 executable=PULUMI_CMD,
                 args=(config_args + ["get", k]),
-                stdout=subprocess.PIPE,
                 stderr=subprocess.DEVNULL,
                 check=True).stdout.decode("utf-8").strip("\n")
         except subprocess.CalledProcessError:
@@ -197,7 +195,7 @@ def set_localstack_pulumi_config(args: argparse.Namespace):
     for idx, service in enumerate(generate_service_endpoints(args)):
         config_args.extend(set_config_options(is_path=True, **{f"aws:endpoints[{idx}].{service}": service_url}))
     try:
-        subprocess.run(executable=PULUMI_CMD, args=config_args, stdout=subprocess.PIPE, check=True)
+        subprocess.run(executable=PULUMI_CMD, args=config_args, check=True)
     except subprocess.CalledProcessError as e:
         exit(e.returncode)
 

--- a/bin/pulumilocal
+++ b/bin/pulumilocal
@@ -55,6 +55,7 @@ if PULUMI_CMD == "pulumilocal":
 
 PULUMI_CMD = which(PULUMI_CMD)
 
+
 def deactivate_access_key(access_key: str) -> str:
     """Safe guarding user from accidental live credential usage by deactivating access key IDs.
         See more: https://docs.localstack.cloud/references/credentials/"""

--- a/bin/pulumilocal
+++ b/bin/pulumilocal
@@ -182,8 +182,8 @@ def set_localstack_pulumi_config(args: argparse.Namespace):
                 executable=PULUMI_CMD,
                 args=(config_args + ["get", k]),
                 stderr=subprocess.DEVNULL,
+                stdout=subprocess.PIPE,
                 check=True,
-                capture_output=True,
                 bufsize=0,
             ).stdout.decode("utf-8").strip("\n")
         except subprocess.CalledProcessError:

--- a/bin/pulumilocal
+++ b/bin/pulumilocal
@@ -95,7 +95,7 @@ def generate_service_endpoints(args) -> Dict:
     if args.cwd:
         cmd_args.extend(("--cwd", args.cwd))
     try:
-        sp = subprocess.run(executable=PULUMI_CMD, args=cmd_args, check=True)
+        sp = subprocess.run(executable=PULUMI_CMD, args=cmd_args, check=True, bufsize=0)
     except subprocess.CalledProcessError as e:
         exit(e.returncode)
     plugins = json.loads(sp.stdout.decode("utf-8")).get("plugins")
@@ -105,7 +105,7 @@ def generate_service_endpoints(args) -> Dict:
         version = ""
     config_args = [PULUMI_CMD, "package", "get-schema", f"aws{version}"]
     try:
-        sp = subprocess.run(executable=PULUMI_CMD, args=config_args, check=True)
+        sp = subprocess.run(executable=PULUMI_CMD, args=config_args, check=True, bufsize=0)
     except subprocess.CalledProcessError as e:
         exit(e.returncode)
     schema = json.loads(sp.stdout.decode("utf-8"))
@@ -156,7 +156,8 @@ def set_localstack_pulumi_config(args: argparse.Namespace):
         subprocess.run(
             executable=PULUMI_CMD,
             args=(config_args + ["set-all"] + set_config_options(is_path=True, **{"aws:endpoints": ""})),
-            check=True
+            check=True,
+            bufsize=0,
         )
     except subprocess.CalledProcessError as e:
         exit(e.returncode)
@@ -180,7 +181,10 @@ def set_localstack_pulumi_config(args: argparse.Namespace):
                 executable=PULUMI_CMD,
                 args=(config_args + ["get", k]),
                 stderr=subprocess.DEVNULL,
-                check=True).stdout.decode("utf-8").strip("\n")
+                check=True,
+                capture_output=True,
+                bufsize=0,
+            ).stdout.decode("utf-8").strip("\n")
         except subprocess.CalledProcessError:
             pass
         else:
@@ -195,7 +199,7 @@ def set_localstack_pulumi_config(args: argparse.Namespace):
     for idx, service in enumerate(generate_service_endpoints(args)):
         config_args.extend(set_config_options(is_path=True, **{f"aws:endpoints[{idx}].{service}": service_url}))
     try:
-        subprocess.run(executable=PULUMI_CMD, args=config_args, check=True)
+        subprocess.run(executable=PULUMI_CMD, args=config_args, check=True, bufsize=0)
     except subprocess.CalledProcessError as e:
         exit(e.returncode)
 
@@ -236,7 +240,8 @@ def main():
                 args.stack = subprocess.run(
                     [PULUMI_CMD, "stack", "--show-name", "--non-interactive", "-C", args.cwd],
                     check=True,
-                    capture_output=True
+                    capture_output=True,
+                    bufsize=0,
                 ).stdout.decode("utf-8").strip("\n")
             except (subprocess.CalledProcessError) as e:
                 print(e.stderr.decode("utf-8"), file=sys.stderr)
@@ -253,7 +258,8 @@ def main():
             subprocess.run(
                 [PULUMI_CMD, "stack", "init", "--non-interactive", "-s", LS_STACK_NAME, "-C", args.cwd],
                 check=False,
-                stderr=subprocess.DEVNULL
+                stderr=subprocess.DEVNULL,
+                bufsize=0,
             )
             override_config_file = os.path.join(os.path.dirname(config_file_path), f"Pulumi.{LS_STACK_NAME}.yaml")
             if override_config_file != config_file_path:
@@ -268,7 +274,7 @@ def main():
         if args.non_interactive and "--non-interactive" not in sys.argv:
             sys.argv.append("--non-interactive")
         try:
-            subprocess.run(executable=PULUMI_CMD, args=sys.argv, check=True)
+            subprocess.run(executable=PULUMI_CMD, args=sys.argv, check=True, bufsize=0)
         except subprocess.CalledProcessError as e:
             print(e.stderr.decode("utf-8"), file=sys.stderr)
         finally:

--- a/bin/pulumilocal
+++ b/bin/pulumilocal
@@ -16,6 +16,7 @@ import json
 from typing import Dict, List
 from shutil import copyfile
 from urllib.parse import urlparse
+from shutil import which
 
 # for local testing
 PARENT_FOLDER = os.path.realpath(os.path.join(os.path.dirname(__file__), ".."))
@@ -47,6 +48,7 @@ PROXIED_CMDS = (
 if PULUMI_CMD == "pulumilocal":
     PULUMI_CMD = "pulumi"
 
+PULUMI_CMD = which(PULUMI_CMD)
 
 def deactivate_access_key(access_key: str) -> str:
     """Safe guarding user from accidental live credential usage by deactivating access key IDs.

--- a/bin/pulumilocal
+++ b/bin/pulumilocal
@@ -53,6 +53,7 @@ PROXIED_CMDS = (
 if PULUMI_CMD == "pulumilocal":
     PULUMI_CMD = "pulumi"
 
+# Look up path
 PULUMI_CMD = which(PULUMI_CMD)
 
 


### PR DESCRIPTION
# Motivation

This is a group of fixes:
- reported problems with executable resolution on Windows (#30)
- Additionally we've found `pulumilocal --help` displays the wrong help.
- Under CMD and PowerShell our stdout (unique to Python) seems to have buffering issues (#31)

# Changes
- fix path issue, by looking up the executable on the PATH
- fix help issue, by allowing missing positional arguments
- fix stdout issue, add bufsize to `subprocess.run`, remove `os.execpv` and overdefine print to use flush by default
