### PR TITLE
update setup-localstack version

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,7 +21,7 @@ jobs:
       uses: actions/checkout@v3
 
     - name: Start LocalStack
-      uses: LocalStack/setup-localstack@v0.2.3
+      uses: LocalStack/setup-localstack@v0.2.4
       with:
         image-tag: 'latest'
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,7 +21,7 @@ jobs:
       uses: actions/checkout@v3
 
     - name: Start LocalStack
-      uses: LocalStack/setup-localstack@v0.1.2
+      uses: LocalStack/setup-localstack@v0.2.3
       with:
         image-tag: 'latest'
 


### PR DESCRIPTION
# Motivation

As we are approaching release v4, we are trying to run all pipelines against the `latest` image. I that noticed in the action we were not installing the right version of localstack. Probably not relevant as the image used is built with `latest`, but worth fixing nonetheless.

We were only testing against localstack version `3.2.0` due to the setup tools distname issue. localstack/plux/pull/27. The following log is repeated for all version of LocalStack in the `Start LocalStack` step in https://github.com/localstack/pulumi-local/actions/runs/11916531999/job/33209401793.

```sh
Collecting localstack
  Downloading localstack-3.8.0.tar.gz (5.7 kB)
  Preparing metadata (setup.py): started
  Preparing metadata (setup.py): finished with status 'done'
Collecting localstack-ext==3.8.0
  Downloading localstack_ext-3.8.0.tar.gz (7.8 MB)
     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 7.8/7.8 MB 96.0 MB/s eta 0:00:00
  Installing build dependencies: started
  Installing build dependencies: finished with status 'done'
  Getting requirements to build wheel: started
  Getting requirements to build wheel: finished with status 'done'
  Preparing metadata (pyproject.toml): started
  Preparing metadata (pyproject.toml): finished with status 'done'
  WARNING: Generating metadata for package localstack-ext produced metadata for project name unknown. Fix your #egg=localstack-ext fragments.
Discarding https://files.pythonhosted.org/packages/38/aa/1a7e1f54caf844dbc51[185](https://github.com/localstack/pulumi-local/actions/runs/11916531999/job/33209401793#step:3:187)a95af145c804ec0457f9202241babc865d3eb9/localstack_ext-3.8.0.tar.gz#sha256=fd16779a199f462577dd7f7cd7a52536ad09f10efc649c1c150de62c541c7690 (from https://pypi.org/simple/localstack-ext/) (requires-python:>=3.8): Requested unknown from https://files.pythonhosted.org/packages/38/aa/1a7e1f54caf844dbc51185a95af145c804ec0457f9202241babc865d3eb9/localstack_ext-3.8.0.tar.gz#sha256=fd16779a199f462577dd7f7cd7a52536ad09f10efc649c1c150de62c541c7690 (from localstack) has inconsistent name: filename has 'localstack-ext', but metadata has 'unknown'
```

And the docker start showing

```sh
     __                     _______ __             __
    / /   ____  _________ _/ / ___// /_____ ______/ /__
   / /   / __ \/ ___/ __ `/ /\__ \/ __/ __ `/ ___/ //_/
  / /___/ /_/ / /__/ /_/ / /___/ / /_/ /_/ / /__/ ,<
 /_____/\____/\___/\__,_/_//____/\__/\__,_/\___/_/|_|

 💻 LocalStack CLI 3.2.0
 👤 Profile: default
```
